### PR TITLE
Fix generation of initialisation values for fields of type enum

### DIFF
--- a/compiler/src/main/java/com/github/thake/avro4k/compiler/Avro4kCompiler.java
+++ b/compiler/src/main/java/com/github/thake/avro4k/compiler/Avro4kCompiler.java
@@ -568,6 +568,9 @@ public class Avro4kCompiler {
         if (defaultValue == JsonProperties.NULL_VALUE) {
             return "null";
         }
+        if (field.schema().getType() == Schema.Type.ENUM) {
+            return fullName(field.schema()) + "." + defaultValue;
+        }
         Optional<LogicalTypeConversion> logicalType = getLogicalTypeConversion(field.schema());
         if (logicalType.isPresent()) {
             return logicalType.get().getKotlinDefaultString(field.schema(), defaultValue);

--- a/compiler/src/test/resources/roundtrip/default_values.avsc
+++ b/compiler/src/test/resources/roundtrip/default_values.avsc
@@ -34,6 +34,20 @@
       "default": "Str"
     },
     {
+      "name": "enumValue",
+      "type": {
+        "type": "enum",
+        "name": "Suit",
+        "symbols": [
+          "SPADES",
+          "HEARTS",
+          "DIAMONDS",
+          "CLUBS"
+        ]
+      },
+      "default": "SPADES"
+    },
+    {
       "name": "decimalValue",
       "type": [
         "null",


### PR DESCRIPTION
I noticed that the compiler would generate string literals when building fields of type enum (instead of using the actual enum value).

This PR adds a test case to `default_values.avsc` and adds the necessary code to generate valid (default) initialization values for enum fields.